### PR TITLE
Compatibility updates for keras 0.3.2 and 1.0.4

### DIFF
--- a/1100cars_functional_keras-1.0.4.py
+++ b/1100cars_functional_keras-1.0.4.py
@@ -1,0 +1,136 @@
+import os
+import sys
+import pickle
+import zipfile
+
+import numpy as np
+from keras.callbacks import EarlyStopping
+from keras.layers.convolutional import Convolution2D, MaxPooling2D
+from keras.layers.core import Dense, Activation, Dropout, Flatten, Reshape
+from keras.layers import Input
+from keras.models import Sequential,Model
+
+from autoencoder_layers_keras_1_0 import DependentDense, Deconvolution2D, DePool2D
+from helpers import tile_raster_images, show_image, keras2rgb
+
+
+def load_cars(split=0.8, python_version=3):
+    # Vehicle images are courtecy of German Aerospace Center (DLR)
+    # Remote Sensing Technology Institute, Photogrammetry and Image Analysis
+    # http://www.dlr.de/eoc/en/desktopdefault.aspx/tabid-5431/9230_read-42467/
+    if not os.path.exists('./data/cars.pkl'):
+        print('Extracting cars dataset')
+        with zipfile.ZipFile('./data/cars.pkl.zip', "r") as z:
+            z.extractall("./data/")
+    
+    # if we're using python 3
+    if python_version == 3:
+        with open('./data/cars.pkl', 'rb') as ff:
+            (X_data, y_data) = pickle.load(ff)
+    else:
+        with open('./data/cars_py2.pkl', 'rb') as ff:
+            (X_data, y_data) = pickle.load(ff)
+    
+    X_data = X_data.reshape(X_data.shape[0], 3, 32, 32)
+    l = int(split * X_data.shape[0])
+    X_train = X_data[:l]
+    X_test = X_data[l:]
+
+    return X_train, X_test
+
+
+def build_model_functional(nb_pool=2, nb_conv=3):
+    channels = 3
+    C_1 = 64
+    C_2 = 32
+    C_3 = 16
+    code_length=100
+    
+    input_layer = Input(name='input_layer', 
+                        shape=(channels,32,32))
+    
+    c1 = Convolution2D(C_1, nb_conv, nb_conv, 
+                      border_mode='same',
+                      name='c1',
+                      activation='tanh')(input_layer)
+    mp1 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                      name='mp1')(c1)
+    c2 = Convolution2D(C_2, nb_conv, nb_conv, 
+                       border_mode='same',
+                       name='c2',
+                       activation='tanh')(mp1)
+    mp2 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                       name='mp2')(c2)
+    c3 = Convolution2D(C_3, nb_conv, nb_conv, 
+                       border_mode='same',
+                       name='c3',
+                       activation='tanh')(mp2)
+    mp3 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                       name='mp3')(c3)
+    flat3 = Flatten(name='flat3')(mp3)
+    code = Dense(output_dim=code_length, 
+              name='code',
+              activation='tanh')(flat3)
+    
+    code_prime = DependentDense(output_dim=C_3*4*4, 
+                        master_layer=code,
+                        name='code_prime')(code)
+    code_reshaped = Reshape(target_shape=(C_3, 4, 4),
+                         name='code_reshaped')(code_prime)
+    dep3 = DePool2D(master_layer=mp3, 
+                    size=(nb_pool, nb_pool),
+                    name='dep3')(code_reshaped)
+    dec3 = Deconvolution2D(master_layer=c3, 
+                           #nb_out_channels=C_2, 
+                           border_mode='same',
+                           name='dec3',
+                           activation='tanh')(dep3)
+    dep2 = DePool2D(master_layer=mp2, 
+                    size=(nb_pool, nb_pool),
+                    name='dep2')(dec3)
+    dec2 = Deconvolution2D(master_layer=c2, 
+                           #nb_out_channels=C_1, 
+                           border_mode='same',
+                           name='dec2',
+                           activation='tanh')(dep2)
+    dep1 = DePool2D(master_layer=mp1, 
+                    size=(nb_pool, nb_pool),
+                    name='dep1')(dec2)
+    dec1 = Deconvolution2D(master_layer=c1, 
+                           #nb_out_channels=3, 
+                           border_mode='same',
+                           name='dec1',
+                           activation='tanh')(dep1)          
+    
+    model = Model(input_layer,dec1)
+    model.compile('adam', loss='mean_squared_error')
+    #model.compile('rmsprop', loss='mean_squared_error')
+
+    return model
+
+if __name__ == '__main__':
+    X_train, X_test = load_cars(python_version=sys.version_info.major)
+    model = build_model_functional()
+    if not False:
+        model.summary()
+        model.fit(X_train, X_train, nb_epoch=100, batch_size=64,
+                  validation_split=0.2,
+                  callbacks=[EarlyStopping(patience=12)])
+        model.save_weights('./cars.neuro', overwrite=True)
+    else:
+        model.load_weights('./cars.neuro')
+
+    l = model.predict(X_test[:25, ...])
+    representations = np.clip(l, 0, 1)
+
+    _r = tile_raster_images(
+            X=keras2rgb(representations),
+            img_shape=(32, 32, 3), tile_shape=(5, 5),
+            tile_spacing=(1, 1))
+
+    _o = tile_raster_images(
+            X=keras2rgb(X_test),
+            img_shape=(32, 32, 3), tile_shape=(5, 5),
+            tile_spacing=(1, 1))
+
+    show_image([(_o, 'Source'), (_r, 'Representations')])

--- a/1100cars_sequential_keras-0.3.2.py
+++ b/1100cars_sequential_keras-0.3.2.py
@@ -1,0 +1,129 @@
+import os
+import pickle
+import zipfile
+
+import numpy as np
+from keras.callbacks import EarlyStopping
+from keras.layers.convolutional import Convolution2D, MaxPooling2D
+from keras.layers.core import Dense, Activation, Dropout, Flatten, Reshape
+from keras.models import Sequential
+
+from autoencoder_layers import DependentDense, Deconvolution2D, DePool2D
+from helpers import tile_raster_images, show_image, keras2rgb
+
+
+def load_cars(split=0.8):
+    # Vehicle images are courtecy of German Aerospace Center (DLR)
+    # Remote Sensing Technology Institute, Photogrammetry and Image Analysis
+    # http://www.dlr.de/eoc/en/desktopdefault.aspx/tabid-5431/9230_read-42467/
+    if not os.path.exists('./data/cars.pkl'):
+        print('Extracting cars dataset')
+        with zipfile.ZipFile('./data/cars.pkl.zip', "r") as z:
+            z.extractall("./data/")
+
+    with open('./data/cars.pkl', 'rb') as ff:
+        (X_data, y_data) = pickle.load(ff)
+    X_data = X_data.reshape(X_data.shape[0], 3, 32, 32)
+    l = int(split * X_data.shape[0])
+    X_train = X_data[:l]
+    X_test = X_data[l:]
+
+    return X_train, X_test
+
+
+def build_model(nb_filters=32, nb_pool=2, nb_conv=3):
+    C_1 = 64
+    C_2 = 32
+    C_3 = 16
+    c1 = Convolution2D(C_1, nb_conv, nb_conv, 
+                      border_mode='same',
+                      name='c1',
+                      input_shape=(3, 32, 32))
+    mp1 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                      name='mp1')
+    c2 = Convolution2D(C_2, nb_conv, nb_conv, 
+                       border_mode='same',
+                       name='c2')
+    mp2 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                       name='mp2')
+    c3 = Convolution2D(C_3, nb_conv, nb_conv, 
+                       border_mode='same',
+                       name='c3')
+    mp3 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                       name='mp3')
+    d = Dense(100, 
+              name='encoded')
+    
+    model = Sequential()
+    # ====================================================
+    model.add(c1)
+    model.add(Activation('tanh'))
+    model.add(mp1)
+    # ====================================================
+    model.add(Dropout(0.25))
+    # ====================================================
+    model.add(c2)
+    model.add(Activation('tanh'))
+    model.add(mp2)
+    # ====================================================
+    model.add(c3)
+    model.add(Activation('tanh'))
+    model.add(mp3)
+    # ====================================================
+    model.add(Dropout(0.25))
+    # ====================================================
+    model.add(Flatten())
+    model.add(d)
+    model.add(Activation('tanh'))
+
+    # ====================================================
+
+    model.add(DependentDense(d.input_shape[1], d, input_shape=(d.output_shape[1],)))
+    model.add(Activation('tanh'))
+    model.add(Reshape((C_3, 4, 4)))
+    # ====================================================
+    model.add(DePool2D(mp3, size=(nb_pool, nb_pool)))
+    model.add(Deconvolution2D(c3, nb_out_channels=C_2, border_mode='same'))
+    model.add(Activation('tanh'))
+    # ====================================================
+    model.add(DePool2D(mp2, size=(nb_pool, nb_pool)))
+    model.add(Deconvolution2D(c2, nb_out_channels=C_1, border_mode='same'))
+    model.add(Activation('tanh'))
+    # ====================================================
+    model.add(DePool2D(mp1, size=(nb_pool, nb_pool)))
+    model.add(Deconvolution2D(c1, nb_out_channels=3, border_mode='same'))
+    model.add(Activation('tanh'))
+    # ====================================================
+    
+    model.compile('adam', loss='mean_squared_error')
+    #model.compile('rmsprop', loss='mean_squared_error')
+
+    return model
+
+
+if __name__ == '__main__':
+    X_train, X_test = load_cars()
+    model = build_model()
+    if not False:
+        model.summary()
+        model.fit(X_train, X_train, nb_epoch=5, batch_size=64,
+                  validation_split=0.2,
+                  callbacks=[EarlyStopping(patience=12)])
+        model.save_weights('./cars.neuro', overwrite=True)
+    else:
+        model.load_weights('./cars.neuro')
+
+    l = model.predict(X_test[:25, ...])
+    representations = np.clip(l, 0, 1)
+
+    _r = tile_raster_images(
+            X=keras2rgb(representations),
+            img_shape=(32, 32, 3), tile_shape=(5, 5),
+            tile_spacing=(1, 1))
+
+    _o = tile_raster_images(
+            X=keras2rgb(X_test),
+            img_shape=(32, 32, 3), tile_shape=(5, 5),
+            tile_spacing=(1, 1))
+
+    show_image([(_o, 'Source'), (_r, 'Representations')])

--- a/1100cars_sequential_keras-1.0.4.py
+++ b/1100cars_sequential_keras-1.0.4.py
@@ -1,0 +1,136 @@
+import os
+import sys
+import pickle
+import zipfile
+
+import numpy as np
+from keras.callbacks import EarlyStopping
+from keras.layers.convolutional import Convolution2D, MaxPooling2D
+from keras.layers.core import Dense, Activation, Dropout, Flatten, Reshape
+from keras.models import Sequential
+
+from autoencoder_layers_keras_1_0 import DependentDense, Deconvolution2D, DePool2D
+from helpers import tile_raster_images, show_image, keras2rgb
+
+
+def load_cars(split=0.8, python_version=3):
+    # Vehicle images are courtecy of German Aerospace Center (DLR)
+    # Remote Sensing Technology Institute, Photogrammetry and Image Analysis
+    # http://www.dlr.de/eoc/en/desktopdefault.aspx/tabid-5431/9230_read-42467/
+    if not os.path.exists('./data/cars.pkl'):
+        print('Extracting cars dataset')
+        with zipfile.ZipFile('./data/cars.pkl.zip', "r") as z:
+            z.extractall("./data/")
+    
+    # if we're using python 3
+    if python_version == 3:
+        with open('./data/cars.pkl', 'rb') as ff:
+            (X_data, y_data) = pickle.load(ff)
+    else:
+        with open('./data/cars_py2.pkl', 'rb') as ff:
+            (X_data, y_data) = pickle.load(ff)
+    
+    X_data = X_data.reshape(X_data.shape[0], 3, 32, 32)
+    l = int(split * X_data.shape[0])
+    X_train = X_data[:l]
+    X_test = X_data[l:]
+
+    return X_train, X_test
+
+
+def build_model(nb_filters=32, nb_pool=2, nb_conv=3):
+    C_1 = 64
+    C_2 = 32
+    C_3 = 16
+    c1 = Convolution2D(C_1, nb_conv, nb_conv, 
+                      border_mode='same',
+                      name='c1',
+                      input_shape=(3, 32, 32))
+    mp1 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                      name='mp1')
+    c2 = Convolution2D(C_2, nb_conv, nb_conv, 
+                       border_mode='same',
+                       name='c2')
+    mp2 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                       name='mp2')
+    c3 = Convolution2D(C_3, nb_conv, nb_conv, 
+                       border_mode='same',
+                       name='c3')
+    mp3 = MaxPooling2D(pool_size=(nb_pool, nb_pool),
+                       name='mp3')
+    d = Dense(100, 
+              name='encoded')
+    
+    model = Sequential()
+    # ====================================================
+    model.add(c1)
+    model.add(Activation('tanh'))
+    model.add(mp1)
+    # ====================================================
+    model.add(Dropout(0.25))
+    # ====================================================
+    model.add(c2)
+    model.add(Activation('tanh'))
+    model.add(mp2)
+    # ====================================================
+    model.add(c3)
+    model.add(Activation('tanh'))
+    model.add(mp3)
+    # ====================================================
+    model.add(Dropout(0.25))
+    # ====================================================
+    model.add(Flatten())
+    model.add(d)
+    model.add(Activation('tanh'))
+
+    # ====================================================
+
+    model.add(DependentDense(d.input_shape[1], d, input_shape=(d.output_shape[1],)))
+    model.add(Activation('tanh'))
+    model.add(Reshape((C_3, 4, 4)))
+    # ====================================================
+    model.add(DePool2D(mp3, size=(nb_pool, nb_pool)))
+    model.add(Deconvolution2D(c3, nb_out_channels=C_2, border_mode='same'))
+    model.add(Activation('tanh'))
+    # ====================================================
+    model.add(DePool2D(mp2, size=(nb_pool, nb_pool)))
+    model.add(Deconvolution2D(c2, nb_out_channels=C_1, border_mode='same'))
+    model.add(Activation('tanh'))
+    # ====================================================
+    model.add(DePool2D(mp1, size=(nb_pool, nb_pool)))
+    model.add(Deconvolution2D(c1, nb_out_channels=3, border_mode='same'))
+    model.add(Activation('tanh'))
+    # ====================================================
+    
+    model.compile('adam', loss='mean_squared_error')
+    #model.compile('rmsprop', loss='mean_squared_error')
+
+    return model
+
+
+if __name__ == '__main__':
+    X_train, X_test = load_cars(python_version=sys.version_info.major)
+    model = build_model()
+    if not False:
+        model.summary()
+        model.fit(X_train, X_train, nb_epoch=100, batch_size=64,
+                  validation_split=0.2,
+                  callbacks=[EarlyStopping(patience=12)])
+        model.save_weights('./cars.neuro', overwrite=True)
+    else:
+        model.load_weights('./cars.neuro')
+
+    l = model.predict(X_test[:25, ...])
+    representations = np.clip(l, 0, 1)
+
+    _r = tile_raster_images(
+            X=keras2rgb(representations),
+            img_shape=(32, 32, 3), tile_shape=(5, 5),
+            tile_spacing=(1, 1))
+
+    _o = tile_raster_images(
+            X=keras2rgb(X_test),
+            img_shape=(32, 32, 3), tile_shape=(5, 5),
+            tile_spacing=(1, 1))
+
+    show_image([(_o, 'Source'), (_r, 'Representations')])

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is an implementation of weight-tieing layers that can be used to consturct convolutional autoencoder and 
 simple fully connected autoencoder. It might feel be a bit hacky towards, however it does the job.
 
-It requires Python3.x ([Why?](http://python3wos.appspot.com/)), and keras 0.3.2, e.g. via `pip install keras==0.3.2`.
+It requires Python3.x [Why?](http://python3wos.appspot.com/).
 
 
 ## Convolutional autoencoder [CAE] example 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 This is an implementation of weight-tieing layers that can be used to consturct convolutional autoencoder and 
 simple fully connected autoencoder. It might feel be a bit hacky towards, however it does the job.
 
-It requires Python3.x. [Why?](http://python3wos.appspot.com/)
+It requires Python3.x ([Why?](http://python3wos.appspot.com/)), and keras 0.3.2. 
+
 
 ## Convolutional autoencoder [CAE] example 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is an implementation of weight-tieing layers that can be used to consturct convolutional autoencoder and 
 simple fully connected autoencoder. It might feel be a bit hacky towards, however it does the job.
 
-It requires Python3.x ([Why?](http://python3wos.appspot.com/)), and keras 0.3.2. 
+It requires Python3.x ([Why?](http://python3wos.appspot.com/)), and keras 0.3.2, e.g. via `pip install keras==0.3.2`.
 
 
 ## Convolutional autoencoder [CAE] example 

--- a/autoencoder_layers.py
+++ b/autoencoder_layers.py
@@ -9,7 +9,7 @@ from theano.sandbox.cuda import dnn
 
 class SumLayer(Layer):
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super(SumLayer,self).__init__(**kwargs)
 
     @property
     def output_shape(self):

--- a/autoencoder_layers.py
+++ b/autoencoder_layers.py
@@ -46,7 +46,7 @@ class DePool2D(UpSampling2D):
 
     def __init__(self, pool2d_layer, *args, **kwargs):
         self._pool2d_layer = pool2d_layer
-        super().__init__(*args, **kwargs)
+        super(DePool2D,self).__init__(*args, **kwargs)
 
     def get_output(self, train=False):
         X = self.get_input(train)
@@ -191,7 +191,7 @@ class Deconvolution2D(Convolution2D):
         kwargs['nb_filter'] = self._binded_conv_layer.nb_filter
         kwargs['nb_row'] = self._binded_conv_layer.nb_row
         kwargs['nb_col'] = self._binded_conv_layer.nb_col
-        super().__init__(*args, **kwargs)
+        super(Deconvolution2D,self).__init__(*args, **kwargs)
 
     def build(self):
         self.W = self._binded_conv_layer.W.dimshuffle((1, 0, 2, 3))
@@ -224,7 +224,7 @@ class Deconvolution2D(Convolution2D):
 
     @property
     def output_shape(self):
-        output_shape = list(super().output_shape)
+        output_shape = list(super(Deconvolution2D,self).output_shape)
 
         if self.dim_ordering == 'th':
             output_shape[1] = self.nb_out_channels
@@ -276,7 +276,7 @@ class DependentDense(Dense):
                  W_regularizer=None, b_regularizer=None, activity_regularizer=None,
                  W_constraint=None, b_constraint=None, input_dim=None, **kwargs):
         self.master_layer = master_layer
-        super().__init__(output_dim, **kwargs)
+        super(DependentDense,self).__init__(output_dim, **kwargs)
 
     def build(self):
         self.W = self.master_layer.W.T

--- a/autoencoder_layers.py
+++ b/autoencoder_layers.py
@@ -44,8 +44,8 @@ class DePool2D(UpSampling2D):
     '''
     input_ndim = 4
 
-    def __init__(self, pool2d_layer, *args, **kwargs):
-        self._pool2d_layer = pool2d_layer
+    def __init__(self, master_layer, *args, **kwargs):
+        self._master_layer = master_layer
         super(DePool2D,self).__init__(*args, **kwargs)
 
     def get_output(self, train=False):
@@ -59,7 +59,7 @@ class DePool2D(UpSampling2D):
         else:
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
 
-        f = T.grad(T.sum(self._pool2d_layer.get_output(train)), wrt=self._pool2d_layer.get_input(train)) * output
+        f = T.grad(T.sum(self._master_layer.get_output(train)), wrt=self._master_layer.get_input(train)) * output
 
         return f
 
@@ -185,16 +185,16 @@ class Deconvolution2D(Convolution2D):
     '''
     input_ndim = 4
 
-    def __init__(self, binded_conv_layer, nb_out_channels=1, *args, **kwargs):
-        self._binded_conv_layer = binded_conv_layer
+    def __init__(self, master_layer, nb_out_channels=1, *args, **kwargs):
+        self._master_layer = master_layer
         self.nb_out_channels = nb_out_channels
-        kwargs['nb_filter'] = self._binded_conv_layer.nb_filter
-        kwargs['nb_row'] = self._binded_conv_layer.nb_row
-        kwargs['nb_col'] = self._binded_conv_layer.nb_col
+        kwargs['nb_filter'] = self._master_layer.nb_filter
+        kwargs['nb_row'] = self._master_layer.nb_row
+        kwargs['nb_col'] = self._master_layer.nb_col
         super(Deconvolution2D,self).__init__(*args, **kwargs)
 
     def build(self):
-        self.W = self._binded_conv_layer.W.dimshuffle((1, 0, 2, 3))
+        self.W = self._master_layer.W.dimshuffle((1, 0, 2, 3))
         if self.dim_ordering == 'th':
             self.W_shape = (self.nb_out_channels, self.nb_filter, self.nb_row, self.nb_col)
         elif self.dim_ordering == 'tf':

--- a/autoencoder_layers_keras_1_0.py
+++ b/autoencoder_layers_keras_1_0.py
@@ -1,4 +1,3 @@
-import theano
 from keras import backend as K
 from keras.backend.theano_backend import _on_gpu
 from keras.layers.convolutional import Convolution2D, UpSampling2D

--- a/autoencoder_layers_keras_1_0.py
+++ b/autoencoder_layers_keras_1_0.py
@@ -1,0 +1,301 @@
+import theano
+from keras import backend as K
+from keras.backend.theano_backend import _on_gpu
+from keras.layers.convolutional import Convolution2D, UpSampling2D
+from keras.layers.core import Dense, Layer
+from theano import tensor as T
+from theano.sandbox.cuda import dnn
+
+
+class SumLayer(Layer):
+    def __init__(self, **kwargs):
+        super(SumLayer,self).__init__(**kwargs)
+
+    @property
+    def output_shape(self):
+        input_shape = self.input_shape
+        return (input_shape[0], 1, input_shape[2], input_shape[3])
+
+    def get_output(self, train=False):
+        X = self.get_input(train)
+        return X.sum(axis=1, keepdims=True)
+
+
+class DePool2D(UpSampling2D):
+    '''Similar to UpSample, yet traverse only maxpooled elements
+
+    # Input shape
+        4D tensor with shape:
+        `(samples, channels, rows, cols)` if dim_ordering='th'
+        or 4D tensor with shape:
+        `(samples, rows, cols, channels)` if dim_ordering='tf'.
+
+    # Output shape
+        4D tensor with shape:
+        `(samples, channels, upsampled_rows, upsampled_cols)` if dim_ordering='th'
+        or 4D tensor with shape:
+        `(samples, upsampled_rows, upsampled_cols, channels)` if dim_ordering='tf'.
+
+    # Arguments
+        size: tuple of 2 integers. The upsampling factors for rows and columns.
+        dim_ordering: 'th' or 'tf'.
+            In 'th' mode, the channels dimension (the depth)
+            is at index 1, in 'tf' mode is it at index 3.
+    '''
+    input_ndim = 4
+
+    def __init__(self, pool2d_layer, *args, **kwargs):
+        self._pool2d_layer = pool2d_layer
+        super(DePool2D,self).__init__(*args, **kwargs)
+
+    def get_output(self, train=False):
+        X = self.get_input(train)
+        if self.dim_ordering == 'th':
+            output = K.repeat_elements(X, self.size[0], axis=2)
+            output = K.repeat_elements(output, self.size[1], axis=3)
+        elif self.dim_ordering == 'tf':
+            output = K.repeat_elements(X, self.size[0], axis=1)
+            output = K.repeat_elements(output, self.size[1], axis=2)
+        else:
+            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
+  
+        f = K.gradients(K.sum(self._pool2d_layer.get_output(train)), 
+                        self._pool2d_layer.get_input(train)) * output
+  
+        return f
+
+
+def deconv2d_fast(x, kernel, strides=(1, 1), border_mode='valid', dim_ordering='th',
+                  image_shape=None, filter_shape=None):
+    '''
+    Run on cuDNN if available.
+    border_mode: string, "same" or "valid".
+    '''
+    if dim_ordering not in {'th', 'tf'}:
+        raise Exception('Unknown dim_ordering ' + str(dim_ordering))
+
+    if dim_ordering == 'tf':
+        # TF uses the last dimension as channel dimension,
+        # instead of the 2nd one.
+        # TH input shape: (samples, input_depth, rows, cols)
+        # TF input shape: (samples, rows, cols, input_depth)
+        # TH kernel shape: (depth, input_depth, rows, cols)
+        # TF kernel shape: (rows, cols, input_depth, depth)
+        x = x.dimshuffle((0, 3, 1, 2))
+        kernel = kernel.dimshuffle((3, 2, 0, 1))
+        if image_shape:
+            image_shape = (image_shape[0], image_shape[3],
+                           image_shape[1], image_shape[2])
+        if filter_shape:
+            filter_shape = (filter_shape[3], filter_shape[2],
+                            filter_shape[0], filter_shape[1])
+
+    if _on_gpu() and dnn.dnn_available():
+        if border_mode == 'same':
+            assert (strides == (1, 1))
+            conv_out = dnn.dnn_conv(img=x,
+                                    kerns=kernel,
+                                    border_mode='full')
+            shift_x = (kernel.shape[2] - 1) // 2
+            shift_y = (kernel.shape[3] - 1) // 2
+            conv_out = conv_out[:, :,
+                       shift_x:x.shape[2] + shift_x,
+                       shift_y:x.shape[3] + shift_y]
+        else:
+            conv_out = dnn.dnn_conv(img=x,
+                                    conv_mode='cross',
+                                    kerns=kernel,
+                                    border_mode=border_mode,
+                                    subsample=strides)
+    else:
+        if border_mode == 'same':
+            th_border_mode = 'full'
+            assert (strides == (1, 1))
+        elif border_mode == 'valid':
+            th_border_mode = 'valid'
+        else:
+            raise Exception('Border mode not supported: ' + str(border_mode))
+
+        conv_out = T.nnet.conv2d(x, kernel,
+                                 border_mode=th_border_mode,
+                                 subsample=strides,
+                                 filter_flip=False,  # <<<<< IMPORTANT 111, dont flip kern
+                                 input_shape=image_shape,
+                                 filter_shape=filter_shape)
+        if border_mode == 'same':
+            shift_x = (kernel.shape[2] - 1) // 2
+            shift_y = (kernel.shape[3] - 1) // 2
+            conv_out = conv_out[:, :,
+                       shift_x:x.shape[2] + shift_x,
+                       shift_y:x.shape[3] + shift_y]
+    if dim_ordering == 'tf':
+        conv_out = conv_out.dimshuffle((0, 2, 3, 1))
+    return conv_out
+
+
+class Deconvolution2D(Convolution2D):
+    '''Convolution operator for filtering windows of two-dimensional inputs.
+    When using this layer as the first layer in a model,
+    provide the keyword argument `input_shape`
+    (tuple of integers, does not include the sample axis),
+    e.g. `input_shape=(3, 128, 128)` for 128x128 RGB pictures.
+
+    # Input shape
+        4D tensor with shape:
+        `(samples, channels, rows, cols)` if dim_ordering='th'
+        or 4D tensor with shape:
+        `(samples, rows, cols, channels)` if dim_ordering='tf'.
+
+    # Output shape
+        4D tensor with shape:
+        `(samples, nb_filter, nb_row, nb_col)` if dim_ordering='th'
+        or 4D tensor with shape:
+        `(samples, nb_row, nb_col, nb_filter)` if dim_ordering='tf'.
+
+
+    # Arguments
+        nb_filter: Number of convolution filters to use.
+        nb_row: Number of rows in the convolution kernel.
+        nb_col: Number of columns in the convolution kernel.
+        init: name of initialization function for the weights of the layer
+            (see [initializations](../initializations.md)), or alternatively,
+            Theano function to use for weights initialization.
+            This parameter is only relevant if you don't pass
+            a `weights` argument.
+        activation: name of activation function to use
+            (see [activations](../activations.md)),
+            or alternatively, elementwise Theano function.
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: a(x) = x).
+        weights: list of numpy arrays to set as initial weights.
+        border_mode: 'valid' or 'same'.
+        subsample: tuple of length 2. Factor by which to subsample output.
+            Also called strides elsewhere.
+        W_regularizer: instance of [WeightRegularizer](../regularizers.md)
+            (eg. L1 or L2 regularization), applied to the main weights matrix.
+        b_regularizer: instance of [WeightRegularizer](../regularizers.md),
+            applied to the bias.
+        activity_regularizer: instance of [ActivityRegular            print(single_image.shape)izer](../regularizers.md),
+            applied to the network output.
+        W_constraint: instance of the [constraints](../constraints.md) module
+            (eg. maxnorm, nonneg), applied to the main weights matrix.
+        b_constraint: instance of the [constraints](../constraints.md) module,
+            applied to the bias.
+        dim_ordering: 'th' or 'tf'. In 'th' mode, the channels dimension
+            (the depth) is at index 1, in 'tf' mode is it at index 3.
+    '''
+    input_ndim = 4
+
+    def __init__(self, binded_conv_layer, nb_out_channels=1, *args, **kwargs):
+        self._binded_conv_layer = binded_conv_layer
+        self.nb_out_channels = nb_out_channels
+        kwargs['nb_filter'] = self._binded_conv_layer.nb_filter
+        kwargs['nb_row'] = self._binded_conv_layer.nb_row
+        kwargs['nb_col'] = self._binded_conv_layer.nb_col
+        super(Deconvolution2D,self).__init__(*args, **kwargs)
+
+    def build(self, input_shape):
+        self.W = self._binded_conv_layer.W.dimshuffle((1, 0, 2, 3))
+        if self.dim_ordering == 'th':
+            self.W_shape = (self.nb_out_channels, self.nb_filter, self.nb_row, self.nb_col)
+        elif self.dim_ordering == 'tf':
+            raise NotImplementedError()
+        else:
+            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
+
+        self.b = K.zeros((self.nb_out_channels,))
+        self.params = [self.b]
+        self.regularizers = []
+
+        if self.W_regularizer:
+            self.W_regularizer.set_param(self.W)
+            self.regularizers.append(self.W_regularizer)
+
+        if self.b_regularizer:
+            self.b_regularizer.set_param(self.b)
+            self.regularizers.append(self.b_regularizer)
+
+        if self.activity_regularizer:
+            self.activity_regularizer.set_layer(self)
+            self.regularizers.append(self.activity_regularizer)
+
+        if self.initial_weights is not None:
+            self.set_weights(self.initial_weights)
+            del self.initial_weights
+
+
+    def get_output_shape_for(self, input_shape):
+        output_shape = list(super(Deconvolution2D,self).get_output_shape_for(input_shape))
+
+        if self.dim_ordering == 'th':
+            output_shape[1] = self.nb_out_channels
+        elif self.dim_ordering == 'tf':
+            output_shape[0] = self.nb_out_channels
+        else:
+            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
+        return tuple(output_shape)
+
+
+    def call(self, x, mask=None):
+        conv_out = deconv2d_fast(x, self.W,
+                                 strides=self.subsample,
+                                 border_mode=self.border_mode,
+                                 dim_ordering=self.dim_ordering,
+                                 filter_shape=self.W_shape)
+    
+        if self.dim_ordering == 'th':
+            output = conv_out + K.reshape(self.b, (1, self.nb_out_channels, 1, 1))
+        elif self.dim_ordering == 'tf':
+            output = conv_out + K.reshape(self.b, (1, 1, 1, self.nb_out_channels))
+        else:
+            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
+    
+        output = self.activation(output)
+        return output
+
+
+    def get_config(self):
+        config = {'nb_filter': self.nb_filter,
+                  'nb_row': self.nb_row,
+                  'nb_col': self.nb_col,
+                  'init': self.init.__name__,
+                  'activation': self.activation.__name__,
+                  'border_mode': self.border_mode,
+                  'subsample': self.subsample,
+                  'dim_ordering': self.dim_ordering,
+                  'W_regularizer': self.W_regularizer.get_config() if self.W_regularizer else None,
+                  'b_regularizer': self.b_regularizer.get_config() if self.b_regularizer else None,
+                  'activity_regularizer': self.activity_regularizer.get_config() if self.activity_regularizer else None,
+                  'W_constraint': self.W_constraint.get_config() if self.W_constraint else None,
+                  'b_constraint': self.b_constraint.get_config() if self.b_constraint else None}
+        base_config = super(Deconvolution2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class DependentDense(Dense):
+    def __init__(self, output_dim, master_layer, init='glorot_uniform', activation='linear', weights=None,
+                 W_regularizer=None, b_regularizer=None, activity_regularizer=None,
+                 W_constraint=None, b_constraint=None, input_dim=None, **kwargs):
+        self.master_layer = master_layer
+        super(DependentDense,self).__init__(output_dim, **kwargs)
+
+    def build(self, input_shape):
+        self.W = self.master_layer.W.T
+        self.b = K.zeros((self.output_dim,))
+        self.params = [self.b]
+        self.regularizers = []
+        if self.W_regularizer:
+            self.W_regularizer.set_param(self.W)
+            self.regularizers.append(self.W_regularizer)
+
+        if self.b_regularizer:
+            self.b_regularizer.set_param(self.b)
+            self.regularizers.append(self.b_regularizer)
+
+        if self.activity_regularizer:
+            self.activity_regularizer.set_layer(self)
+            self.regularizers.append(self.activity_regularizer)
+
+        if self.initial_weights is not None:
+            self.set_weights(self.initial_weights)
+            del self.initial_weights


### PR DESCRIPTION
This PR fixes #7, and works with keras 0.3.2 installed via `pip install keras==0.3.2`. 
